### PR TITLE
Disable mqtt integration

### DIFF
--- a/configuration/chirpstack-application-server/chirpstack-application-server.toml
+++ b/configuration/chirpstack-application-server/chirpstack-application-server.toml
@@ -209,7 +209,7 @@ id="6d5db27e-4ce2-4b2b-b5d7-91f069397978"
   # * gcp_pub_sub       - Google Cloud Pub/Sub
   # * kafka             - Kafka distributed streaming platform
   # * postgresql        - PostgreSQL database
-  enabled=["mqtt"]
+  enabled=[]
 
 
   # MQTT integration backend.

--- a/configuration/chirpstack-application-server/chirpstack-application-server.toml
+++ b/configuration/chirpstack-application-server/chirpstack-application-server.toml
@@ -228,13 +228,13 @@ id="6d5db27e-4ce2-4b2b-b5d7-91f069397978"
   retain_events=false
 
   # MQTT server (e.g. scheme://host:port where scheme is tcp, ssl or ws)
-  server="tcp://83.166.154.87:1884"
+  server=""
 
   # Connect with the given username (optional)
-  username="railnet"
+  username=""
 
   # Connect with the given password (optional)
-  password="m0cbid"
+  password=""
 
   # Maximum interval that will be waited between reconnection attempts when connection is lost.
   # Valid units are 'ms', 's', 'm', 'h'. Note that these values can be combined, e.g. '24h30m15s'.

--- a/configuration/mosquitto/mosquitto.conf
+++ b/configuration/mosquitto/mosquitto.conf
@@ -531,7 +531,7 @@ port 1883
 # autosave_on_changes.
 # Note that writing of the persistence database can be forced by
 # sending mosquitto a SIGUSR1 signal.
-#autosave_interval 1800
+autosave_interval 900
 
 # If true, mosquitto will count the number of subscription changes, retained
 # messages received and queued messages and if the total exceeds
@@ -549,7 +549,7 @@ persistence true
 
 # The filename to use for the persistent database, not including
 # the path.
-#persistence_file mosquitto.db
+persistence_file mosquitto_chirpstack.db
 
 # Location for persistent database. Must include trailing /
 # Default is an empty string (current directory).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: "3"
 
+
 services:
   chirpstack-network-server:
     image: chirpstack/chirpstack-network-server:3.10.0
@@ -22,7 +23,7 @@ services:
       - POSTGRES_PASSWORD=root
     volumes:
       - ./configuration/postgresql/initdb:/docker-entrypoint-initdb.d
-      - postgresqldata:/var/lib/postgresql/data
+      - /mnt/VM/docker/chirpstack/postgresqldata:/var/lib/postgresql/data
 
   redis:
     image: redis:5-alpine
@@ -37,9 +38,7 @@ services:
       - 1885:1883
     volumes:
       - ./configuration/mosquitto/:/mosquitto/config/
-      - mosquittoData:/mosquitto/data
+      - /mnt/VM/docker/chirpstack/broker_mqtt:/mosquitto/data
 
 volumes:
-  postgresqldata:
   redisdata:
-  mosquittoData:


### PR DESCRIPTION
PR en discussion sur le choix de valider ou non la comm d'integration CS en MQTT.  La trame MQTT cs ne respecte pas la trame de Mr Adrien Martin . 

Dans ce PR j'ai desactivé la config mqtt . 
A vous de decider .

Que le meilleur qui cause gagne ;) 