### PR TITLE
[JIRA STIMCLOUD-336] Change postgres tag version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - ./configuration/chirpstack-application-server:/etc/chirpstack-application-server
 
   postgresql:
-    image: postgres:9.6-alpine
+    image: postgres:9.6.20-alpine
     container_name: cs-postgres
     environment:
       - POSTGRES_PASSWORD=root


### PR DESCRIPTION
Correctif pour l'ajout du tag complet pour la base Postgres .

Le fait de laisser le tag "image: postgres:9.6-alpine" fait que l'on pointe sur la derniere evolution de la base ( il y a qlqs jours c'etait la version image: postgres:9.6.17-alpine aujourd'hui c'est la image: postgres:9.6.20-alpine)

Les scripts de backup  ne fonctionnaient pas avec l'ancienne version !
 

